### PR TITLE
MSWin32 support

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -8,10 +8,18 @@ use My::Build;
 # prevent warnings about missing share directory
 make_path("share");
 
-my $builder = My::Build->new(
+my %module_build_args = (
     ##{ $plugin->get_prereqs ##}
     ##{ $plugin->get_default(qw/dist_name license dist_abstract/) ##}
     ##{ $plugin->get_default(qw/dist_author/) ##}
+);
+
+if($^O eq 'MSWin32') {
+    $module_build_args{build_requires}{'Alien::MSYS'} = '0';
+}
+
+my $builder = My::Build->new(
+    %module_build_args,
     dist_version_from => "lib/Alien/ZMQ.pm",
     share_dir => "share",
 );

--- a/inc/My/Build.pm
+++ b/inc/My/Build.pm
@@ -182,7 +182,18 @@ sub install_zeromq {
     my $run_env = sub { $_[0]->() };
     if($^O eq 'MSWin32') {
         require Alien::MSYS;
-        $run_env = \&Alien::MSYS::msys;
+        $run_env = sub {
+            my ($old_prefix, $old_datadir) = ($prefix, $datadir);
+            for my $dir ($prefix, $datadir) {
+                # turn Windows path into MSYS path
+                $dir =~ s|^(\w):|/$1|;
+                $dir =~ s|\\|/|g;
+            }
+
+            &Alien::MSYS::msys; # call with same arguments
+
+            ($prefix, $datadir) = ($old_prefix, $old_prefix);
+        };
     }
 
     print "Patching...\n";

--- a/inc/My/Build.pm
+++ b/inc/My/Build.pm
@@ -180,8 +180,10 @@ sub install_zeromq {
     chdir $srcdir;
 
     print "Patching...\n";
+    # Strawberry Perl needs --binary flag to deal with newlines or it crashes
+    my @patch_binary = $^O eq 'MSWin32' ? qw(--binary) : ();
     for my $patch (glob("$basedir/files/zeromq-$version-*.patch")) {
-	run [qw/patch -p1/], '<', $patch or die "Failed to patch libzmq";
+        run [qw/patch -p1/, @patch_binary], '<', $patch or die "Failed to patch libzmq";
     }
 
     print "Configuring...\n";

--- a/inc/My/Build.pm
+++ b/inc/My/Build.pm
@@ -11,6 +11,7 @@ use File::Spec::Functions qw/catdir catfile/;
 use IPC::Run qw/run/;
 use LWP::Simple qw/getstore RC_OK/;
 use Module::Build;
+use B;
 
 use base 'Module::Build';
 
@@ -44,8 +45,8 @@ sub ACTION_code {
     open my $LIB, '<', $module or die "Cannot read module";
     my $lib = do { local $/; <$LIB> };
     close $LIB;
-    $lib =~ s/^sub inc_dir.*$/sub inc_dir { "$vars{inc_dir}" }/m;
-    $lib =~ s/^sub lib_dir.*$/sub lib_dir { "$vars{lib_dir}" }/m;
+    $lib =~ s/^sub inc_dir.*$/sub inc_dir { @{[ B::perlstring($vars{inc_dir}) ]} }/m;
+    $lib =~ s/^sub lib_dir.*$/sub lib_dir { @{[ B::perlstring($vars{lib_dir}) ]} }/m;
     $lib =~ s/^sub inc_version.*$/sub inc_version { v$vars{inc_version} }/m;
     $lib =~ s/^sub lib_version.*$/sub lib_version { v$vars{lib_version} }/m;
     my @stats = stat $module;


### PR DESCRIPTION
This addresses the issue at https://github.com/chazmcgarvey/p5-Alien-ZMQ/issues/1.

The only remaining problem is that building static libraries under MinGW does not work from what I have tested under zeromq-3.2.4 and zeromq-3.2.5. It might be possible to make it work by [patching](http://comments.gmane.org/gmane.network.zeromq.devel/19489).

This is a problem because MSWin32 requires that when `ZMQ::LibZMQ3` is dynamically linked, the DLL must be in the `%PATH%` at runtime. I'll try and see if I can figure out a patch for `ZMQ::LibZMQ3`.
